### PR TITLE
Versons, builder config, and metadata

### DIFF
--- a/cmd/otelcontribcol/builder-config.yaml
+++ b/cmd/otelcontribcol/builder-config.yaml
@@ -496,3 +496,4 @@ replaces:
   - github.com/open-telemetry/opentelemetry-collector-contrib/receiver/githubreceiver => ../../receiver/githubreceiver
   - github.com/open-telemetry/opentelemetry-collector-contrib/internal/grpcutil => ../../internal/grpcutil
   - github.com/open-telemetry/opentelemetry-collector-contrib/receiver/googlecloudmonitoringreceiver => ../../receiver/googlecloudmonitoringreceiver
+  - github.com/open-telemetry/opentelemetry-collector-contrib/pkg/status => ../../pkg/status

--- a/pkg/status/metadata.yml
+++ b/pkg/status/metadata.yml
@@ -1,0 +1,3 @@
+status:
+  codeowners:
+    active: [jpkrohling, mwear]

--- a/versions.yaml
+++ b/versions.yaml
@@ -149,6 +149,7 @@ module-sets:
       - github.com/open-telemetry/opentelemetry-collector-contrib/pkg/sampling
       - github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza
       - github.com/open-telemetry/opentelemetry-collector-contrib/pkg/datadog
+      - github.com/open-telemetry/opentelemetry-collector-contrib/pkg/status
       - github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/azure
       - github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/azurelogs
       - github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/jaeger


### PR DESCRIPTION
I fixed a couple of issues with https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/35648. The CI checks will likely turn up more, but this is a start.